### PR TITLE
Include cstddef

### DIFF
--- a/include/sds/sds_fstream.h
+++ b/include/sds/sds_fstream.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include <string>
+#include <cstddef>
 
 namespace sds
 {

--- a/include/sds/sds_fstreamApk.h
+++ b/include/sds/sds_fstreamApk.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "sds_fstream.h"
+#include <cstddef>
 
 struct AAsset;
 typedef struct AAssetManager AAssetManager;

--- a/include/sds/sds_fstreamNsud.h
+++ b/include/sds/sds_fstreamNsud.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include <string>
+#include <cstddef>
 
 namespace sds
 {

--- a/src/sds/sds_fstream.cpp
+++ b/src/sds/sds_fstream.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 
 #include <limits>
+#include <cstddef>
 
 #ifdef WIN32
 #	include <io.h>


### PR DESCRIPTION
I had to add these includes for clang to find `ptrdiff_t` while building Colibri.